### PR TITLE
docs: add .env.example with required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# ============================================
+# convergio-cli — Environment Variables
+# ============================================
+
+# --- Authentication (required) ---
+# Auth token for Convergio API
+CONVERGIO_AUTH_TOKEN=your-auth-token-here
+
+# --- AI Provider ---
+# Anthropic API key for direct Claude access
+# ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# --- Configuration ---
+# Path to peers configuration file
+# CONVERGIO_PEERS_CONF=/path/to/peers.toml
+
+# Agent identifier for CLI sessions
+# CVG_AGENT_ID=my-agent-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.env


### PR DESCRIPTION
## Changes

Adds `.env.example` documenting all environment variables used by convergio-cli.

## Variables

| Variable | Required | Description |
|----------|----------|-------------|
| CONVERGIO_AUTH_TOKEN | Yes | Auth token for Convergio API |
| ANTHROPIC_API_KEY | No | Anthropic API key for direct Claude access |
| CONVERGIO_PEERS_CONF | No | Path to peers configuration file |
| CVG_AGENT_ID | No | Agent identifier for CLI sessions |