### PR TITLE
chore: bump convergio-sdk to v0.1.9 (security fixes)

### DIFF
--- a/crates/convergio-cli/src/cli_ops.rs
+++ b/crates/convergio-cli/src/cli_ops.rs
@@ -215,7 +215,7 @@ fn compute_mesh_signature(body: &[u8]) -> Option<String> {
     if secret.is_empty() {
         return None;
     }
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
     let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
     mac.update(body);

--- a/crates/convergio-cli/src/cli_setup.rs
+++ b/crates/convergio-cli/src/cli_setup.rs
@@ -45,7 +45,7 @@ pub(crate) async fn handle_setup(defaults: bool) -> Result<(), CliError> {
     }
     let role_idx = Select::new()
         .with_prompt("Select role")
-        .items(&ROLES)
+        .items(ROLES)
         .default(0)
         .interact()
         .map_err(|e| CliError::InvalidInput(e.to_string()))?;

--- a/crates/convergio-cli/src/cli_setup_inference.rs
+++ b/crates/convergio-cli/src/cli_setup_inference.rs
@@ -148,7 +148,7 @@ fn select_mlx_model() -> Result<String, CliError> {
     }
     let idx = Select::new()
         .with_prompt("  Select MLX model")
-        .items(&models)
+        .items(models)
         .default(0)
         .interact()
         .map_err(|e| CliError::InvalidInput(e.to_string()))?;


### PR DESCRIPTION
## Changes

Bumps convergio-sdk from v0.1.7 to v0.1.9.

### SDK v0.1.9 security fixes
- JWT empty-key auth bypass
- SQL injection guard
- SSRF bypass protection
- RBAC path overmatch
- Audit hash verification
- Path traversal fix

## Verification
- cargo check ✓
- Fixed KeyInit trait import for Hmac API changes