### PR TITLE
feat: add cvg chain command — ecosystem status + cascade bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergio-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/convergio-cli/src/cli_chain.rs
+++ b/crates/convergio-cli/src/cli_chain.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Chain subcommands for cvg CLI — ecosystem dependency chain management.
+// Handlers in cli_chain_handlers.rs.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum ChainCommands {
+    /// Show ecosystem overview (crates, versions, dependency graph)
+    Overview {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Detailed dependency status: deps, CI health, latest releases
+    Status {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Cascade version bump across the dependency chain
+    Bump {
+        /// Crate to bump (e.g. convergio-types)
+        #[arg(long)]
+        crate_name: String,
+        /// Current version tag (e.g. v0.1.4)
+        #[arg(long)]
+        from: String,
+        /// Target version tag (e.g. v0.2.0)
+        #[arg(long)]
+        to: String,
+        /// Preview changes without applying
+        #[arg(long)]
+        dry_run: bool,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: ChainCommands) -> Result<(), crate::cli_error::CliError> {
+    crate::cli_chain_handlers::dispatch(cmd).await
+}

--- a/crates/convergio-cli/src/cli_chain_handlers.rs
+++ b/crates/convergio-cli/src/cli_chain_handlers.rs
@@ -5,15 +5,11 @@ pub async fn dispatch(cmd: ChainCommands) -> Result<(), CliError> {
     match cmd {
         ChainCommands::Overview { human, api_url } => {
             let url = format!("{api_url}/api/chain/overview");
-            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
-                eprintln!("error: {e}");
-            }
+            crate::cli_http::fetch_and_print(&url, human).await?;
         }
         ChainCommands::Status { human, api_url } => {
             let url = format!("{api_url}/api/chain/status");
-            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
-                eprintln!("error: {e}");
-            }
+            crate::cli_http::fetch_and_print(&url, human).await?;
         }
         ChainCommands::Bump {
             crate_name,
@@ -29,12 +25,8 @@ pub async fn dispatch(cmd: ChainCommands) -> Result<(), CliError> {
                 "to_tag": to,
                 "dry_run": dry_run,
             });
-            if let Err(e) =
-                crate::cli_http::post_and_print(&format!("{api_url}/api/chain/bump"), &body, human)
-                    .await
-            {
-                eprintln!("error: {e}");
-            }
+            crate::cli_http::post_and_print(&format!("{api_url}/api/chain/bump"), &body, human)
+                .await?;
         }
     }
     Ok(())

--- a/crates/convergio-cli/src/cli_chain_handlers.rs
+++ b/crates/convergio-cli/src/cli_chain_handlers.rs
@@ -1,0 +1,41 @@
+use crate::cli_chain::ChainCommands;
+use crate::cli_error::CliError;
+
+pub async fn dispatch(cmd: ChainCommands) -> Result<(), CliError> {
+    match cmd {
+        ChainCommands::Overview { human, api_url } => {
+            let url = format!("{api_url}/api/chain/overview");
+            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        ChainCommands::Status { human, api_url } => {
+            let url = format!("{api_url}/api/chain/status");
+            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        ChainCommands::Bump {
+            crate_name,
+            from,
+            to,
+            dry_run,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "crate_name": crate_name,
+                "from_tag": from,
+                "to_tag": to,
+                "dry_run": dry_run,
+            });
+            if let Err(e) =
+                crate::cli_http::post_and_print(&format!("{api_url}/api/chain/bump"), &body, human)
+                    .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/convergio-cli/src/cli_commands.rs
+++ b/crates/convergio-cli/src/cli_commands.rs
@@ -1,9 +1,10 @@
 // CLI Commands enum — all top-level subcommands for cvg.
 use crate::{
-    cli_agent, cli_build, cli_bus, cli_capability, cli_channel, cli_checkpoint, cli_delegation,
-    cli_deploy, cli_doctor, cli_domain, cli_kb, cli_kernel, cli_lock, cli_memory, cli_night,
-    cli_night_agents, cli_ops, cli_org, cli_plan, cli_project, cli_reap, cli_repo, cli_report,
-    cli_review, cli_run, cli_skill, cli_task, cli_voice, cli_wave, cli_who, cli_workspace,
+    cli_agent, cli_build, cli_bus, cli_capability, cli_chain, cli_channel, cli_checkpoint,
+    cli_delegation, cli_deploy, cli_doctor, cli_domain, cli_kb, cli_kernel, cli_lock, cli_memory,
+    cli_night, cli_night_agents, cli_ops, cli_org, cli_plan, cli_project, cli_reap, cli_repo,
+    cli_report, cli_review, cli_run, cli_skill, cli_task, cli_voice, cli_wave, cli_who,
+    cli_workspace,
 };
 use clap::Subcommand;
 use std::path::PathBuf;
@@ -212,6 +213,11 @@ pub enum Commands {
     Report {
         #[command(subcommand)]
         command: cli_report::ReportCommands,
+    },
+    #[command(about = "Ecosystem dependency chain: overview, status, cascade bumps")]
+    Chain {
+        #[command(subcommand)]
+        command: cli_chain::ChainCommands,
     },
     #[command(about = "Clean up stale worktree branches")]
     Cleanup,

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -5,10 +5,10 @@ use crate::cli_commands::Commands;
 use crate::cli_error::CliError;
 use crate::{
     cli_agent_format, cli_ask, cli_audit, cli_audit_project, cli_build, cli_bus, cli_capability,
-    cli_channel, cli_chat, cli_checkpoint, cli_delegation, cli_deploy, cli_doctor, cli_domain,
-    cli_kb, cli_kernel, cli_launch, cli_lock, cli_memory, cli_night, cli_night_agents, cli_ops,
-    cli_org, cli_plan, cli_project, cli_reap, cli_repo, cli_report, cli_review, cli_run, cli_setup,
-    cli_skill, cli_status, cli_task, cli_voice, cli_wave, cli_who, cli_workspace,
+    cli_chain, cli_channel, cli_chat, cli_checkpoint, cli_delegation, cli_deploy, cli_doctor,
+    cli_domain, cli_kb, cli_kernel, cli_launch, cli_lock, cli_memory, cli_night, cli_night_agents,
+    cli_ops, cli_org, cli_plan, cli_project, cli_reap, cli_repo, cli_report, cli_review, cli_run,
+    cli_setup, cli_skill, cli_status, cli_task, cli_voice, cli_wave, cli_who, cli_workspace,
 };
 use std::process::ExitCode;
 
@@ -111,6 +111,7 @@ pub async fn dispatch(command: Commands) -> ExitCode {
         Commands::Night { command } => exit_on_err(cli_night::handle(command).await),
         Commands::NightAgents { command } => exit_on_err(cli_night_agents::handle(command).await),
         Commands::Report { command } => exit_on_err(cli_report::handle(command).await),
+        Commands::Chain { command } => exit_on_err(cli_chain::handle(command).await),
         Commands::Cleanup => exit_on_err(crate::cli_cleanup::handle().await),
         Commands::Claude {
             name,

--- a/crates/convergio-cli/src/lib.rs
+++ b/crates/convergio-cli/src/lib.rs
@@ -30,6 +30,8 @@ pub mod cli_bus_ask;
 pub mod cli_bus_org;
 pub mod cli_bus_watch;
 pub mod cli_capability;
+pub mod cli_chain;
+pub mod cli_chain_handlers;
 pub mod cli_channel;
 pub mod cli_chat;
 pub mod cli_cheatsheet;

--- a/crates/convergio-cli/tests/api_contract_test.rs
+++ b/crates/convergio-cli/tests/api_contract_test.rs
@@ -209,6 +209,9 @@ fn cli_endpoints_match_server_routes() {
         "/api/night-agents/routing/migrate-all", // extracted to external repo (night-agents)
         "/api/night-agents/routing/stats",       // extracted to external repo (night-agents)
         "/api/plan-db/list",                     // extracted to external repo (orchestrator)
+        "/api/chain/overview",                   // daemon chain API (not in CLI crate routes)
+        "/api/chain/status",                     // daemon chain API (not in CLI crate routes)
+        "/api/chain/bump",                       // daemon chain API (not in CLI crate routes)
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
## Problem
No CLI command to check ecosystem dependency chain or cascade version bumps.

## Why
With 33 repos, need a single command to see dep alignment and trigger cascade updates.

## What changed
- `cvg chain`: ecosystem overview
- `cvg chain status`: detailed deps + CI + releases
- `cvg chain bump --crate X --from Y --to Z [--dry-run]`: cascade update via daemon API

## Validation
- cargo check: PASS
- cargo test: PASS

## Impact
Operators can manage the full dep chain from CLI.