### PR TITLE
fix(cli): long-running HTTP client for doctor full + stress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/convergio-cli/src/cli_agent_format.rs
+++ b/crates/convergio-cli/src/cli_agent_format.rs
@@ -63,12 +63,18 @@ pub(crate) async fn dispatch(cmd: AgentCommands) -> Result<(), CliError> {
             handle_sync(&source_dir, human, &api_url).await?;
         }
         AgentCommands::Enable {
-            name, human, api_url, ..
+            name,
+            human,
+            api_url,
+            ..
         } => {
             handle_set_status(&name, "active", human, &api_url).await?;
         }
         AgentCommands::Disable {
-            name, human, api_url, ..
+            name,
+            human,
+            api_url,
+            ..
         } => {
             handle_set_status(&name, "disabled", human, &api_url).await?;
         }
@@ -92,16 +98,10 @@ pub(crate) async fn dispatch(cmd: AgentCommands) -> Result<(), CliError> {
         } => {
             handle_triage(&description, domain.as_deref(), human, &api_url).await?;
         }
-        AgentCommands::History {
-            api_url, ..
-        } => {
+        AgentCommands::History { api_url, .. } => {
             // Agent session history endpoint not yet available in daemon.
             // Show currently active agents as fallback.
-            crate::cli_http::fetch_and_print(
-                &format!("{api_url}/api/ipc/agents"),
-                true,
-            )
-            .await?;
+            crate::cli_http::fetch_and_print(&format!("{api_url}/api/ipc/agents"), true).await?;
         }
         AgentCommands::Spawn {
             name,
@@ -148,17 +148,20 @@ async fn handle_set_status(
 ) -> Result<(), CliError> {
     // GET the current agent, update status, PUT back (daemon requires full body on PUT)
     let url = format!("{api_url}/api/agents/catalog/{name}");
-    let mut agent = crate::cli_http::get_and_return(&url).await.map_err(|_| {
-        CliError::NotFound(format!("agent '{name}' not found in catalog"))
-    })?;
+    let mut agent = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::NotFound(format!("agent '{name}' not found in catalog")))?;
     if let Some(obj) = agent.as_object_mut() {
         obj.insert("status".to_string(), serde_json::json!(status));
     }
     // PUT requires name + role + category at minimum
     let client = crate::security::hardened_http_client();
-    let resp = client.put(&url).json(&agent).send().await.map_err(|e| {
-        CliError::ApiCallFailed(format!("error connecting to daemon: {e}"))
-    })?;
+    let resp = client
+        .put(&url)
+        .json(&agent)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
     let resp_status = resp.status();
     if resp_status.as_u16() == 204 {
         // 204 No Content — success with no body
@@ -166,9 +169,10 @@ async fn handle_set_status(
         crate::cli_http::print_value(&val, human);
         return Ok(());
     }
-    let val: serde_json::Value = resp.json().await.map_err(|e| {
-        CliError::ApiCallFailed(format!("error parsing response: {e}"))
-    })?;
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
     crate::cli_http::print_value(&val, human);
     if !resp_status.is_success() {
         return Err(CliError::NotFound(val.to_string()));
@@ -208,12 +212,7 @@ async fn handle_sync(source_dir: &str, human: bool, api_url: &str) -> Result<(),
 
         // Parse YAML frontmatter between --- delimiters
         let frontmatter = if content.starts_with("---") {
-            content
-                .split("---")
-                .nth(1)
-                .unwrap_or("")
-                .trim()
-                .to_string()
+            content.split("---").nth(1).unwrap_or("").trim().to_string()
         } else {
             String::new()
         };
@@ -232,9 +231,9 @@ async fn handle_sync(source_dir: &str, human: bool, api_url: &str) -> Result<(),
             }
         };
 
-        let name = yaml["name"].as_str().unwrap_or(
-            fname.trim_end_matches(".agent.md"),
-        );
+        let name = yaml["name"]
+            .as_str()
+            .unwrap_or(fname.trim_end_matches(".agent.md"));
 
         let body = serde_json::json!({
             "name": name,
@@ -244,11 +243,8 @@ async fn handle_sync(source_dir: &str, human: bool, api_url: &str) -> Result<(),
             "model": yaml["model"].as_str().unwrap_or("claude-sonnet-4-6"),
         });
 
-        match crate::cli_http::post_and_return(
-            &format!("{api_url}/api/agents/catalog"),
-            &body,
-        )
-        .await
+        match crate::cli_http::post_and_return(&format!("{api_url}/api/agents/catalog"), &body)
+            .await
         {
             Ok(_) => {
                 if human {

--- a/crates/convergio-cli/src/cli_http.rs
+++ b/crates/convergio-cli/src/cli_http.rs
@@ -127,7 +127,14 @@ pub async fn post_and_return(
 
 /// GET `url` and return the parsed JSON value without printing.
 pub async fn get_and_return(url: &str) -> Result<serde_json::Value, i32> {
-    let client = crate::security::hardened_http_client();
+    // Doctor full-suite calls run E2E checks that include up-to-45s mesh
+    // sync polling; the default 30s client times out before the response
+    // arrives. Long-running diagnostic endpoints get a 180s budget.
+    let client = if url.contains("/api/doctor/full") || url.contains("/api/stress") {
+        crate::security::long_running_http_client()
+    } else {
+        crate::security::hardened_http_client()
+    };
     match with_auth(client.get(url), url).send().await {
         Ok(resp) => {
             let status = resp.status();

--- a/crates/convergio-cli/src/security.rs
+++ b/crates/convergio-cli/src/security.rs
@@ -134,6 +134,17 @@ pub fn hardened_http_client() -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
+/// HTTP client for endpoints that legitimately exceed 30s
+/// (doctor full suite with mesh sync polling, stress runs, etc.).
+pub fn long_running_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(180))
+        .connect_timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
 /// Write a file with restrictive permissions (0600 on Unix).
 #[cfg(unix)]
 pub fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {


### PR DESCRIPTION
## Problem
Default `hardened_http_client` has a 30s timeout. `cvg doctor full` calls run E2E checks that include up-to-45s mesh sync polling — the client times out before the response arrives, surfacing as spurious failures.

## Why
Doctor full-suite is the canonical pre-release gate. Spurious timeouts make it impossible to trust the result and force re-runs. The fix is small and localized to two endpoints that legitimately exceed 30s.

## What changed
- `crates/convergio-cli/src/security.rs`: new `long_running_http_client()` with 180s timeout (10s connect, 5 redirects).
- `crates/convergio-cli/src/cli_http.rs`: `get_and_return` routes `/api/doctor/full` and `/api/stress` to the new client; everything else stays on `hardened_http_client`.
- `crates/convergio-cli/src/cli_agent_format.rs`: bundled `cargo fmt` pass to clear drift from earlier commits.

## Validation
- `cargo fmt --all -- --check` — clean
- `cargo check` — passes
- Manual: `cvg doctor full` no longer times out at 30s

## Impact
- Doctor full + stress checks complete reliably.
- No change to default client behavior — the long timeout only applies to two well-known long-running endpoints.
- Surface area for the new client is small and easy to extend if more endpoints need it.